### PR TITLE
Prevent space triggering combo box close

### DIFF
--- a/packages/lib/src/lib/combobox.ts
+++ b/packages/lib/src/lib/combobox.ts
@@ -10,7 +10,6 @@ import { keyCharacter } from "./internal/key-character";
 import { keyEscape } from "./internal/key-escape";
 import { keyHomeEnd } from "./internal/key-home-end";
 import { keyUpDown } from "./internal/key-up-down";
-import { keySpaceEnter } from "./internal/key-space-enter";
 import { keyTab } from "./internal/key-tab";
 import { active, defaultList, firstActive, getFocuser, getItemValues, getUpdater, lastActive, nextActive, onDestroy, onSelect, previousActive, removeItem, type ItemOptions, type List, type ListItem } from "./internal/list";
 import { ensureID } from "./internal/new-id";
@@ -28,6 +27,7 @@ import { reflectSelectedValueOnClose } from "./internal/value";
 import { tick } from "svelte";
 import { setDisabled } from "./internal/set-disabled";
 import { getPrefix } from "./internal/utils";
+import { keyEnter } from "./internal/key-enter";
 
 // TODO: add "value" selector, to pick text value off list item objects
 export interface Combobox extends Labelable, Expandable, Controllable, List, Selectable {
@@ -139,7 +139,7 @@ export function createCombobox(init?: Partial<Combobox>) {
       // onClick(toggle),
       // selectAllOnFocus(), <--
       onKeydown(
-        keySpaceEnter(select),  // TODO: should be enter only
+        keyEnter(select),
         keyEscape(close),
         keyHomeEnd(first, last),
         keyUpDown(previous, next),

--- a/packages/lib/src/lib/internal/key-enter.ts
+++ b/packages/lib/src/lib/internal/key-enter.ts
@@ -1,0 +1,4 @@
+import { keyHandler } from "./key-handler"
+import { Enter } from "./keys"
+
+export const keyEnter = keyHandler(Enter)

--- a/packages/lib/src/lib/internal/key-escape.ts
+++ b/packages/lib/src/lib/internal/key-escape.ts
@@ -1,10 +1,4 @@
-import { Escape, type KeyHandler } from "./keys"
+import { keyHandler } from "./key-handler"
+import { Escape } from "./keys"
 
-export const keyEscape = (fn: () => void): KeyHandler => key => {
-  switch (key) {
-    case Escape:
-      fn()
-      return true
-  }
-  return false
-}
+export const keyEscape = keyHandler(Escape)

--- a/packages/lib/src/lib/internal/key-handler.ts
+++ b/packages/lib/src/lib/internal/key-handler.ts
@@ -1,0 +1,10 @@
+import type { KeyHandler } from "./keys"
+
+export const keyHandler = (match: string) => (fn: () => void): KeyHandler => key => {
+  switch (key) {
+    case match:
+      fn()
+      return true
+  }
+  return false
+}

--- a/packages/lib/src/lib/internal/key-space.ts
+++ b/packages/lib/src/lib/internal/key-space.ts
@@ -1,0 +1,4 @@
+import { keyHandler } from "./key-handler"
+import { Space } from "./keys"
+
+export const keySpace = keyHandler(Space)

--- a/packages/lib/src/lib/internal/key-tab.ts
+++ b/packages/lib/src/lib/internal/key-tab.ts
@@ -1,10 +1,4 @@
-import { Tab, type KeyHandler } from "./keys"
+import { keyHandler } from "./key-handler"
+import { Tab } from "./keys"
 
-export const keyTab = (fn: () => void): KeyHandler => key => {
-  switch (key) {
-    case Tab:
-      fn()
-      return true
-  }
-  return false
-}
+export const keyTab = keyHandler(Tab)

--- a/packages/lib/src/lib/internal/on-click-outside.ts
+++ b/packages/lib/src/lib/internal/on-click-outside.ts
@@ -4,6 +4,7 @@ import { listener } from "./events"
 export function onClickOutside(fn: (event: Event) => void, when?: () => boolean): Behavior {
   return node => {
     function handler(event: Event) {
+      if ((event as PointerEvent).pointerType === '') return // ignore space as click
       if (!when || when()) {
         if (node && !node.contains(event.target as Node)) {
           if (node.clientWidth) {

--- a/packages/lib/src/routes/combobox/+page.svelte
+++ b/packages/lib/src/routes/combobox/+page.svelte
@@ -20,7 +20,7 @@
 		console.log('select', (e as CustomEvent).detail)
 	}
 
-	$: filtered = people.filter(person => person.name.toLowerCase().replace(/\s+/g, '').includes($combobox.filter.toLowerCase().replace(/\s+/g, '')))
+	$: filtered = people.filter(person => person.name.toLowerCase().includes($combobox.filter.toLowerCase()))
 </script>
 
 <div class="flex w-full flex-col items-center justify-center">


### PR DESCRIPTION
Wasn't just the key inputs, but the space also triggered `click` (outside)

Need to confirm that checking the `pointerType` for it _not_ being a pointer is a suitable approach

closes #7