### PR TITLE
Support for mobile

### DIFF
--- a/packages/lib/src/lib/combobox.ts
+++ b/packages/lib/src/lib/combobox.ts
@@ -10,7 +10,7 @@ import { keyEscape } from "./internal/key-escape";
 import { keyHomeEnd } from "./internal/key-home-end";
 import { keyUpDown } from "./internal/key-up-down";
 import { keyTab } from "./internal/key-tab";
-import { active, defaultList, firstActive, getFocuser, getUpdater, lastActive, nextActive, onDestroy, onSelect, previousActive, removeItem, type ItemOptions, type List } from "./internal/list";
+import { activate, active, defaultList, firstActive, getFocuser, getUpdater, lastActive, nextActive, onDestroy, onSelect, previousActive, removeItem, type ItemOptions, type List } from "./internal/list";
 import { ensureID } from "./internal/new-id";
 import { noop } from "./internal/noop";
 import { onClick } from "./internal/on-click";
@@ -203,7 +203,7 @@ export function createCombobox(init?: Partial<Combobox>) {
       setRole('listbox'),
       setTabIndex(-1),
       onClickOutside(close),
-      onClick(select),
+      onClick(activate('[role="option"]', focusNode, select)),
       onPointerMoveChild('[role="option"]', focusNode),
       onPointerOut(none),
       // onKeydown(

--- a/packages/lib/src/lib/internal/list.ts
+++ b/packages/lib/src/lib/internal/list.ts
@@ -34,6 +34,12 @@ export const removeItem = (state: List, node: HTMLElement) => {
 
 export const active = (state: List) => state.active === -1 || state.items.length === 0 ? undefined : state.active >= state.items.length ? state.items[state.active] : state.items[state.active].value
 
+export const activate = (selector: string, focus: (node: HTMLElement | null) => void, select: () => void) => (event: Event) => {
+  const el = (event.target as Element).closest(selector)
+  focus(el as HTMLElement)
+  select()
+}
+
 export function onSelect(state: List, node?: HTMLElement) {
   if (state.active === -1 || state.items[state.active].disabled) return {}
   const selected = active(state)

--- a/packages/lib/src/lib/listbox.ts
+++ b/packages/lib/src/lib/listbox.ts
@@ -12,7 +12,7 @@ import { keyHomeEnd } from "./internal/key-home-end";
 import { keyUpDown } from "./internal/key-up-down";
 import { keySpaceEnter } from "./internal/key-space-enter";
 import { keyTab } from "./internal/key-tab";
-import { active, defaultList, firstActive, getFocuser, getSearch, getUpdater, lastActive, nextActive, onDestroy, onSelect, previousActive, removeItem, type ItemOptions, type List } from "./internal/list";
+import { activate, active, defaultList, firstActive, getFocuser, getSearch, getUpdater, lastActive, nextActive, onDestroy, onSelect, previousActive, removeItem, type ItemOptions, type List } from "./internal/list";
 import { ensureID } from "./internal/new-id";
 import { noop } from "./internal/noop";
 import { onClick } from "./internal/on-click";
@@ -118,7 +118,7 @@ export function createListbox<T = any>(init?: Partial<Listbox>) {
       setRole('listbox'),
       setTabIndex(0),
       onClickOutside(close),
-      onClick(select),
+      onClick(activate('[role="option"]', focusNode, select)),
       onPointerMoveChild('[role="option"]', focusNode),
       onPointerOut(none),
       onKeydown(

--- a/packages/lib/src/lib/menu.ts
+++ b/packages/lib/src/lib/menu.ts
@@ -12,7 +12,7 @@ import { keyHomeEnd } from "./internal/key-home-end";
 import { keyUpDown } from "./internal/key-up-down";
 import { keySpaceEnter } from "./internal/key-space-enter";
 import { keyTab } from "./internal/key-tab";
-import { active, defaultList, firstActive, getFocuser, getSearch, getUpdater, lastActive, nextActive, onDestroy, onSelect, previousActive, removeItem, type ItemOptions, type List } from "./internal/list";
+import { activate, active, defaultList, firstActive, getFocuser, getSearch, getUpdater, lastActive, nextActive, onDestroy, onSelect, previousActive, removeItem, type ItemOptions, type List } from "./internal/list";
 import { ensureID } from "./internal/new-id";
 import { noop } from "./internal/noop";
 import { onClick } from "./internal/on-click";
@@ -118,7 +118,7 @@ export function createMenu(init?: Partial<Menu>) {
       setRole('menu'),
       setTabIndex(0),
       onClickOutside(close),
-      onClick(select),
+      onClick(activate('[role="menuitem"]', focusNode, select)),
       onPointerMoveChild('[role="menuitem"]', focusNode),
       onPointerOut(none),
       onKeydown(

--- a/packages/lib/src/lib/tabs.ts
+++ b/packages/lib/src/lib/tabs.ts
@@ -11,7 +11,7 @@ import { keyHomeEnd } from "./internal/key-home-end";
 import { keyUpDown } from "./internal/key-up-down";
 import { keySpaceEnter } from "./internal/key-space-enter";
 import { keyTab } from "./internal/key-tab";
-import { defaultList, firstActive, getFocuser, getSearch, getUpdater, lastActive, nextActive, onDestroy, previousActive, removeItem, type ItemOptions, type List } from "./internal/list";
+import { activate, defaultList, firstActive, getFocuser, getSearch, getUpdater, lastActive, nextActive, onDestroy, previousActive, removeItem, type ItemOptions, type List } from "./internal/list";
 import { ensureID } from "./internal/new-id";
 import { noop } from "./internal/noop";
 import { onClick } from "./internal/on-click";
@@ -125,7 +125,7 @@ export function createTabs(init?: Partial<Tabs>) {
       setRole('menu'),
       setTabIndex(0),
       onClickOutside(close),
-      onClick(select),
+      onClick(activate('[role="option"]', focusNode, select)),
       onPointerMoveChild('[role="menuitem"]', focusNode),
       onPointerOut(none),
       onKeydown(


### PR DESCRIPTION
`onClick` only selected the item that was marked `active`, but `active` was only set on mouseover, so didn't work on mobile.

Changed to activate item that is clicked first using same item-select logic as mouseover.

Closes #6 