### PR TITLE
Rename pkg.main to pkg.module

### DIFF
--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -18,7 +18,7 @@
   "exports": {
     ".": "./dist/index.js"
   },
-  "main": "./dist/index.js",
+  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "homepage": "https://captaincodeman.github.io/svelte-headlessui/",
   "repository": {

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -18,8 +18,8 @@
   "exports": {
     ".": "./dist/index.js"
   },
-  "module": "./dist/index.js",
-  "types": "./dist/index.d.ts",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
   "homepage": "https://captaincodeman.github.io/svelte-headlessui/",
   "repository": {
     "type": "git",


### PR DESCRIPTION
I recently discovered publint, and I've been using it to test svelte libraries as I was working on `@tanstack/svelte-query`. I noticed that it gave one suggestion for this package: https://publint.dev/svelte-headlessui

Since `svelte-headlessui` builds for ESM (as it should), it should use `"module": "dist/index.js"` instead of `"main": "./dist/index.js"`. This probably isn't breaking anything for most people as I'm pretty sure node will read "exports" over "main", but best to fix it just in case.