### PR TITLE
Don't block event propagation

### DIFF
--- a/packages/lib/src/lib/internal/events.ts
+++ b/packages/lib/src/lib/internal/events.ts
@@ -3,10 +3,3 @@ export const listener = <K extends keyof HTMLElementEventMap>(node: HTMLElement,
   node.addEventListener(type, handler, capture)
   return () => node.removeEventListener(type, handler, capture)
 }
-
-// terminateEvent decorates event handlers to preventDefault and stopPropagation of the event
-export const terminateEvent = <T extends Event>(handler: (event: T) => void) => (event: T) => {
-  event.stopPropagation()
-  event.stopImmediatePropagation()
-  handler(event)
-}

--- a/packages/lib/src/lib/internal/on-click.ts
+++ b/packages/lib/src/lib/internal/on-click.ts
@@ -1,3 +1,3 @@
-import { listener, terminateEvent } from "./events"
+import { listener } from "./events"
 
-export const onClick = (fn: (event: Event) => void) => (node: HTMLElement) => listener(node, 'click', terminateEvent(fn))
+export const onClick = (fn: (event: Event) => void) => (node: HTMLElement) => listener(node, 'click', fn)

--- a/packages/lib/src/lib/internal/on-input.ts
+++ b/packages/lib/src/lib/internal/on-input.ts
@@ -1,9 +1,9 @@
-import { listener, terminateEvent } from "./events"
+import { listener } from "./events"
 
 type FilterFn = (value: string) => void
 
 // TODO: ensure node is type HTMLInputElement when applied
-export const onInput = (fn: FilterFn) => (node: HTMLElement) => listener(node, 'input', terminateEvent(event => {
+export const onInput = (fn: FilterFn) => (node: HTMLElement) => listener(node, 'input', event => {
   const el = event.target as HTMLInputElement
   fn(el.value)
-}))
+})


### PR DESCRIPTION
Unnecessary and interfered with SK routing when menu items were anchors

Input event may also be useful to listen to by consumers.

closes #31