### PR TITLE
docs: Add prominent GitHub link to docs

### DIFF
--- a/packages/docs/src/components/Header/Header.astro
+++ b/packages/docs/src/components/Header/Header.astro
@@ -23,6 +23,20 @@ const lang = currentPage && getLanguageFromURL(currentPage)
 			</a>
 		</div>
 		<div style="flex-grow: 1;"></div>
+		<div class="icon">
+			<a
+			href="https://github.com/CaptainCodeman/svelte-headlessui"
+			title="Go to Svelte Headless-UI's repository"
+			rel="external"
+			>
+				<svg viewBox="0 0 24 24" aria-hidden="true" class="w-7 h-7">
+					<path
+						fill="currentColor"
+						d="M12 2A10 10 0 0 0 2 12c0 4.42 2.87 8.17 6.84 9.5.5.08.66-.23.66-.5v-1.69c-2.77.6-3.36-1.34-3.36-1.34-.46-1.16-1.11-1.47-1.11-1.47-.91-.62.07-.6.07-.6 1 .07 1.53 1.03 1.53 1.03.87 1.52 2.34 1.07 2.91.83.09-.65.35-1.09.63-1.34-2.22-.25-4.55-1.11-4.55-4.92 0-1.11.38-2 1.03-2.71-.1-.25-.45-1.29.1-2.64 0 0 .84-.27 2.75 1.02.79-.22 1.65-.33 2.5-.33.85 0 1.71.11 2.5.33 1.91-1.29 2.75-1.02 2.75-1.02.55 1.35.2 2.39.1 2.64.65.71 1.03 1.6 1.03 2.71 0 3.82-2.34 4.66-4.57 4.91.36.31.69.92.69 1.85V21c0 .27.16.59.67.5C19.14 20.16 22 16.42 22 12A10 10 0 0 0 12 2z"
+					/>
+				</svg>
+			</a>
+		</div>
 		{KNOWN_LANGUAGE_CODES.length > 1 && <LanguageSelect lang={lang} client:idle />}
 		{
 			CONFIG.ALGOLIA && (
@@ -70,13 +84,16 @@ const lang = currentPage && getLanguageFromURL(currentPage)
 		font-weight: bold;
 	}
 
-	.logo a {
+	.logo a,
+	.icon a {
 		transition: color 100ms ease-out;
 		color: var(--theme-text);
 	}
 
 	.logo a:hover,
-	.logo a:focus {
+	.logo a:focus,
+	.icon a:hover,
+	.icon a:focus {
 		color: var(--theme-text-accent);
 	}
 


### PR DESCRIPTION
This adds a prominent GitHub link to the docs.

![image](https://user-images.githubusercontent.com/38083522/215099289-1bf9c02e-622c-4bab-b0e8-4eb9410c0f8b.png)
