### PR TITLE
Allow the event to continue bubbling instead of stopping at close

### DIFF
--- a/packages/lib/src/lib/internal/on-click-outside.ts
+++ b/packages/lib/src/lib/internal/on-click-outside.ts
@@ -10,7 +10,6 @@ export function onClickOutside(fn: (event: Event) => void): Behavior {
       if (initial && !node.contains(initial)) {
         if (node.clientWidth) {
           event.preventDefault()
-          event.stopPropagation()
           fn(event)
         }
       }


### PR DESCRIPTION
Bug: When a `Listbox` or `Menu` is open, you have to click outside of it to close it, but the event stops propagating after that so if the click is for something else, you have to click twice.

[Example](https://github.com/CaptainCodeman/svelte-headlessui/assets/1744366/35ea8fe4-82b8-468c-a79e-c161e41157e5)

I tested this behavior in the Headless UI library, and the event does not stop propagating when you click outside of it:

[Demo](https://github.com/CaptainCodeman/svelte-headlessui/assets/1744366/94be0feb-8c45-4982-a681-ef46c80f2197)

It could be that the propagation should be stopped in some situations, but I don't believe it should be for Menu and Listbox. So I don't know if there should be a conditional flag higher up for specific components, since this change would affect the behavior for all components that utilize this.
