### PR TITLE
Dialog ARIA role

### DIFF
--- a/packages/lib/src/lib/dialog.ts
+++ b/packages/lib/src/lib/dialog.ts
@@ -36,7 +36,7 @@ export function createDialog(init?: Partial<Dialog>) {
     ensureID(node, prefix)
 
     const destroy = applyBehaviors(node, [
-      setRole('modal'),
+      setRole('dialog'),
       reflectAriaModal(store),
       reflectAriaLabel(store),
       trapFocusOnOpen(store),


### PR DESCRIPTION
`role="modal"` is not a valid ARIA role, running lighthouse on the [dialog example](https://captaincodeman.github.io/svelte-headlessui/example/dialog/) reveals some ARIA errors:

![image](https://github.com/CaptainCodeman/svelte-headlessui/assets/14295257/6f9f0ee8-56b4-42d1-b91a-e0834e755f7f)

This is a PR to change it to `role="dialog"`

