### PR TITLE
Manage the active item via focus instead constant value

### DIFF
--- a/src/docs/03-combobox.md
+++ b/src/docs/03-combobox.md
@@ -86,13 +86,12 @@ Comboboxes are the foundation of accessible autocompletes and command palettes f
 				>
 					{#each filtered as value}
 						{@const active = $combobox.active === value}
-						{@const selected = $combobox.selected === value}
 						<li
-							class="relative cursor-default select-none py-2 pl-10 pr-4 text-gray-900 focus:outline-none focus:bg-teal-600 focus:text-white group"
+							class="relative cursor-default select-none py-2 pl-10 pr-4 focus:outline-none font-normal aria-selected:font-medium {active ? 'bg-teal-600 text-white' : 'text-gray-900'} group"
 							use:combobox.item={{ value }}
 						>
-							<span class="block truncate font-normal group-aria-selected:font-medium">{value.name}</span>
-							<span class="absolute invisible group-aria-selected:visible inset-y-0 left-0 flex items-center pl-3 text-teal-600 group-focus:text-white">
+							<span class="block truncate">{value.name}</span>
+							<span class="absolute invisible group-aria-selected:visible inset-y-0 left-0 flex items-center pl-3 {active ? 'text-white' : 'text-teal-600'}">
 								<Check class="h-5 w-5" />
 							</span>
 						</li>

--- a/src/docs/03-combobox.md
+++ b/src/docs/03-combobox.md
@@ -88,15 +88,13 @@ Comboboxes are the foundation of accessible autocompletes and command palettes f
 						{@const active = $combobox.active === value}
 						{@const selected = $combobox.selected === value}
 						<li
-							class="relative cursor-default select-none py-2 pl-10 pr-4 {active ? 'bg-teal-600 text-white' : 'text-gray-900'}"
+							class="relative cursor-default select-none py-2 pl-10 pr-4 text-gray-900 focus:outline-none focus:bg-teal-600 focus:text-white group"
 							use:combobox.item={{ value }}
 						>
-							<span class="block truncate {selected ? 'font-medium' : 'font-normal'}">{value.name}</span>
-							{#if selected}
-								<span class="absolute inset-y-0 left-0 flex items-center pl-3 {active ? 'text-white' : 'text-teal-600'}">
-									<Check class="h-5 w-5" />
-								</span>
-							{/if}
+							<span class="block truncate font-normal group-aria-selected:font-medium">{value.name}</span>
+							<span class="absolute invisible group-aria-selected:visible inset-y-0 left-0 flex items-center pl-3 text-teal-600 group-focus:text-white">
+								<Check class="h-5 w-5" />
+							</span>
 						</li>
 					{:else}
 						<li class="relative cursor-default select-none py-2 pl-10 pr-4 text-gray-900">

--- a/src/docs/04-combobox-multi.md
+++ b/src/docs/04-combobox-multi.md
@@ -100,18 +100,14 @@ Pass an array to the `selected` property of `createCombobox` to trigger multi-se
 				class="absolute mt-1 max-h-60 w-full overflow-auto rounded-md bg-white py-1 text-sm shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none"
 			>
 				{#each filtered as value}
-					{@const active = $combobox.active === value}
-					{@const selected = $combobox.selected.includes(value)}
 					<li
-						class="relative cursor-default select-none py-2 pl-4 pr-9 focus:outline-none {active ? 'bg-teal-600 text-white' : 'text-gray-900'}"
+						class="relative cursor-default select-none py-2 pl-4 pr-9 focus:outline-none text-gray-900 focus:bg-teal-600 focus:text-white group"
 						use:combobox.item={{ value }}
 					>
-						<span class="block truncate {selected ? 'font-semibold' : 'font-normal'}">{value.name}</span>
-						{#if selected}
-							<span class="absolute inset-y-0 right-0 flex items-center pr-3 {active ? 'text-white' : 'text-teal-600'}">
-								<Check class="h-5 w-5" />
-							</span>
-						{/if}
+						<span class="block truncate font-normal group-focus:font-semibold">{value.name}</span>
+						<span class="absolute invisible group-aria-selected:visible inset-y-0 right-0 flex items-center pr-3 text-teal-600 group-hover:text-white">
+							<Check class="h-5 w-5" />
+						</span>
 					</li>
 				{:else}
 					<li class="relative cursor-default select-none py-2 pl-10 pr-4 text-gray-900">

--- a/src/docs/04-combobox-multi.md
+++ b/src/docs/04-combobox-multi.md
@@ -100,12 +100,13 @@ Pass an array to the `selected` property of `createCombobox` to trigger multi-se
 				class="absolute mt-1 max-h-60 w-full overflow-auto rounded-md bg-white py-1 text-sm shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none"
 			>
 				{#each filtered as value}
+					{@const active = $combobox.active === value}
 					<li
-						class="relative cursor-default select-none py-2 pl-4 pr-9 focus:outline-none text-gray-900 focus:bg-teal-600 focus:text-white group"
+						class="relative cursor-default select-none py-2 pl-4 pr-9 focus:outline-none font-normal aria-selected:font-medium {active ? 'bg-teal-600 text-white' : 'text-gray-900'} group"
 						use:combobox.item={{ value }}
 					>
-						<span class="block truncate font-normal group-focus:font-semibold">{value.name}</span>
-						<span class="absolute invisible group-aria-selected:visible inset-y-0 right-0 flex items-center pr-3 text-teal-600 group-hover:text-white">
+						<span class="block truncate">{value.name}</span>
+						<span class="absolute invisible group-aria-selected:visible inset-y-0 right-0 flex items-center pr-3 {active ? 'text-white' : 'text-teal-600'}">
 							<Check class="h-5 w-5" />
 						</span>
 					</li>

--- a/src/docs/07-listbox.md
+++ b/src/docs/07-listbox.md
@@ -73,18 +73,14 @@ Listboxes are a great foundation for building custom, accessible select menus fo
 					class="absolute mt-1 max-h-60 w-full overflow-auto rounded-md bg-white py-1 text-sm shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none"
 				>
 					{#each people as value, i}
-						{@const active = $listbox.active === value}
-						{@const selected = $listbox.selected === value}
 						<li
-							class="relative cursor-default select-none py-2 pl-10 pr-4 {active ? 'bg-amber-100 text-amber-900' : 'text-gray-900'}"
+							class="relative cursor-default select-none py-2 pl-10 pr-4 text-gray-900 focus:outline-none focus:bg-amber-100 focus:text-amber-900 group"
 							use:listbox.item={{ value }}
 						>
-							<span class="block truncate {selected ? 'font-medium' : 'font-normal'}">{value.name}</span>
-							{#if selected}
-								<span class="absolute inset-y-0 left-0 flex items-center pl-3 text-amber-600">
-									<Check class="h-5 w-5" />
-								</span>
-							{/if}
+							<span class="block truncate font-normal group-aria-selected:font-medium">{value.name}</span>
+							<span class="absolute invisible group-aria-selected:visible inset-y-0 left-0 flex items-center pl-3 text-amber-600">
+								<Check class="h-5 w-5" />
+							</span>
 						</li>
 					{/each}
 				</ul>

--- a/src/docs/08-listbox-multi.md
+++ b/src/docs/08-listbox-multi.md
@@ -92,18 +92,14 @@ Pass an array to the `selected` property of `createListbox` to trigger multi-sel
 				class="absolute mt-1 max-h-60 w-full overflow-auto rounded-md bg-white py-1 text-sm shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none"
 			>
 				{#each people as value (value.id)}
-					{@const active = $listbox.active === value}
-					{@const selected = $listbox.selected.includes(value)}
 					<li
-						class="relative cursor-default select-none py-2 pl-4 pr-9 focus:outline-none {active ? 'bg-orange-100 text-orange-900' : 'text-gray-900'}"
+						class="relative cursor-default select-none py-2 pl-4 pr-9 text-gray-900 focus:outline-none focus:bg-orange-100 focus:text-orange-900 group"
 						use:listbox.item={{ value }}
 					>
-						<span class="block truncate {selected ? 'font-semibold' : 'font-normal'}">{value.name}</span>
-						{#if selected}
-							<span class="absolute inset-y-0 right-0 flex items-center pr-3 text-orange-600">
-								<Check class="h-5 w-5" />
-							</span>
-						{/if}
+						<span class="block truncate font-normal group-aria-selected:font-semibold">{value.name}</span>
+						<span class="absolute invisible group-aria-selected:visible inset-y-0 right-0 flex items-center pr-3 text-orange-600">
+							<Check class="h-5 w-5" />
+						</span>
 					</li>
 				{/each}
 			</ul>

--- a/src/docs/09-menu.md
+++ b/src/docs/09-menu.md
@@ -91,7 +91,7 @@ Menus offer an easy way to build custom, accessible dropdown components with rob
 								{@const active = $menu.active === option.text}
 								<button
 									use:menu.item
-									class="group flex rounded-md items-center w-full px-2 py-2 text-sm {active ? 'bg-violet-500 text-white' : 'text-gray-900'}"
+									class="group flex rounded-md items-center w-full px-2 py-2 text-sm text-gray-900 focus:outline-none focus:bg-violet-500 focus:text-white"
 								>
 									<svelte:component this={option.icon} class="w-5 h-5 mr-2" {active} />
 									{option.text}

--- a/src/lib/combobox.ts
+++ b/src/lib/combobox.ts
@@ -74,7 +74,7 @@ export function createCombobox(init?: Partial<Combobox>) {
       set({ expanded, opened, active })
       const item = state.items[active]
       if (item) {
-        item.node.scrollIntoView({ block: 'nearest' })
+        item.node.focus();
       }
     }
   }

--- a/src/lib/combobox.ts
+++ b/src/lib/combobox.ts
@@ -74,7 +74,7 @@ export function createCombobox(init?: Partial<Combobox>) {
       set({ expanded, opened, active })
       const item = state.items[active]
       if (item) {
-        item.node.focus();
+        item.node.scrollIntoView({ block: 'nearest' })
       }
     }
   }

--- a/src/lib/listbox.ts
+++ b/src/lib/listbox.ts
@@ -65,7 +65,7 @@ export function createListbox(init?: Partial<Listbox>) {
       set({ active })
       const item = state.items[active]
       if (item) {
-        item.node.scrollIntoView({ block: 'nearest' })
+        item.node.focus()
       }
     }
   }

--- a/src/lib/menu.ts
+++ b/src/lib/menu.ts
@@ -58,7 +58,15 @@ export function createMenu(init?: Partial<Menu>) {
   const toggle = () => state.expanded ? close() : open()
 
   // set focused (active) item (open if not expanded) only if changed
-  const focus = (active: number, expand = false) => state.active !== active && set({ expanded: state.expanded || expand, active })
+  const focus = (active: number, expand = false) => {
+    if (state.active !== active) {
+      set({ expanded: state.expanded || expand, active })
+      const item = state.items[active];
+      if (item) {
+        item.node.focus()
+      }
+    }
+  }
 
   // set focus (active) to first
   const first = () => focus(firstActive(state), true)

--- a/src/routes/example/combobox/+page.svelte
+++ b/src/routes/example/combobox/+page.svelte
@@ -55,10 +55,10 @@
 			>
 				{#each filtered as value}
 					<li
-						class="relative cursor-default select-none py-2 pl-10 pr-4 text-gray-900 focus:outline-none focus:bg-teal-600 focus:text-white group"
+						class="relative cursor-default select-none py-2 pl-10 pr-4 font-normal aria-selected:font-medium text-gray-900 focus:outline-none focus:bg-teal-600 focus:text-white group"
 						use:combobox.item={{ value }}
 					>
-						<span class="block truncate font-normal group-aria-selected:font-medium">{value.name}</span>
+						<span class="block truncate">{value.name}</span>
 						<span class="absolute invisible group-aria-selected:visible inset-y-0 left-0 flex items-center pl-3 text-teal-600 group-focus:text-white">
 							<Check class="h-5 w-5" />
 						</span>

--- a/src/routes/example/combobox/+page.svelte
+++ b/src/routes/example/combobox/+page.svelte
@@ -54,18 +54,14 @@
 				class="absolute mt-1 max-h-60 w-full overflow-auto rounded-md bg-white py-1 text-sm shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none"
 			>
 				{#each filtered as value}
-					{@const active = $combobox.active === value}
-					{@const selected = $combobox.selected === value}
 					<li
-						class="relative cursor-default select-none py-2 pl-10 pr-4 {active ? 'bg-teal-600 text-white' : 'text-gray-900'}"
+						class="relative cursor-default select-none py-2 pl-10 pr-4 text-gray-900 focus:outline-none focus:bg-teal-600 focus:text-white group"
 						use:combobox.item={{ value }}
 					>
-						<span class="block truncate {selected ? 'font-medium' : 'font-normal'}">{value.name}</span>
-						{#if selected}
-							<span class="absolute inset-y-0 left-0 flex items-center pl-3 {active ? 'text-white' : 'text-teal-600'}">
-								<Check class="h-5 w-5" />
-							</span>
-						{/if}
+						<span class="block truncate font-normal group-aria-selected:font-medium">{value.name}</span>
+						<span class="absolute invisible group-aria-selected:visible inset-y-0 left-0 flex items-center pl-3 text-teal-600 group-focus:text-white">
+							<Check class="h-5 w-5" />
+						</span>
 					</li>
 				{:else}
 					<li class="relative cursor-default select-none py-2 pl-10 pr-4 text-gray-900">

--- a/src/routes/example/combobox/+page.svelte
+++ b/src/routes/example/combobox/+page.svelte
@@ -54,12 +54,13 @@
 				class="absolute mt-1 max-h-60 w-full overflow-auto rounded-md bg-white py-1 text-sm shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none"
 			>
 				{#each filtered as value}
+					{@const active = $combobox.active === value}
 					<li
-						class="relative cursor-default select-none py-2 pl-10 pr-4 font-normal aria-selected:font-medium text-gray-900 focus:outline-none focus:bg-teal-600 focus:text-white group"
+						class="relative cursor-default select-none py-2 pl-10 pr-4 focus:outline-none font-normal aria-selected:font-medium {active ? 'bg-teal-600 text-white' : 'text-gray-900'} group"
 						use:combobox.item={{ value }}
 					>
 						<span class="block truncate">{value.name}</span>
-						<span class="absolute invisible group-aria-selected:visible inset-y-0 left-0 flex items-center pl-3 text-teal-600 group-focus:text-white">
+						<span class="absolute invisible group-aria-selected:visible inset-y-0 left-0 flex items-center pl-3 {active ? 'text-white' : 'text-teal-600'}">
 							<Check class="h-5 w-5" />
 						</span>
 					</li>

--- a/src/routes/example/combobox/multi/+page.svelte
+++ b/src/routes/example/combobox/multi/+page.svelte
@@ -70,12 +70,13 @@
 				class="absolute mt-1 max-h-60 w-full overflow-auto rounded-md bg-white py-1 text-sm shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none"
 			>
 				{#each filtered as value}
+					{@const active = $combobox.active === value}
 					<li
-						class="relative cursor-default select-none py-2 pl-4 pr-9 focus:outline-none font-normal aria-selected:font-medium text-gray-900 focus:bg-teal-600 focus:text-white group"
+						class="relative cursor-default select-none py-2 pl-4 pr-9 focus:outline-none font-normal aria-selected:font-medium {active ? 'bg-teal-600 text-white' : 'text-gray-900'} group"
 						use:combobox.item={{ value }}
 					>
 						<span class="block truncate">{value.name}</span>
-						<span class="absolute invisible group-aria-selected:visible inset-y-0 right-0 flex items-center pr-3 text-teal-600 group-hover:text-white">
+						<span class="absolute invisible group-aria-selected:visible inset-y-0 right-0 flex items-center pr-3 {active ? 'text-white' : 'text-teal-600'}">
 							<Check class="h-5 w-5" />
 						</span>
 					</li>

--- a/src/routes/example/combobox/multi/+page.svelte
+++ b/src/routes/example/combobox/multi/+page.svelte
@@ -71,10 +71,10 @@
 			>
 				{#each filtered as value}
 					<li
-						class="relative cursor-default select-none py-2 pl-4 pr-9 focus:outline-none text-gray-900 focus:bg-teal-600 focus:text-white group"
+						class="relative cursor-default select-none py-2 pl-4 pr-9 focus:outline-none font-normal aria-selected:font-medium text-gray-900 focus:bg-teal-600 focus:text-white group"
 						use:combobox.item={{ value }}
 					>
-						<span class="block truncate font-normal group-focus:font-semibold">{value.name}</span>
+						<span class="block truncate">{value.name}</span>
 						<span class="absolute invisible group-aria-selected:visible inset-y-0 right-0 flex items-center pr-3 text-teal-600 group-hover:text-white">
 							<Check class="h-5 w-5" />
 						</span>

--- a/src/routes/example/combobox/multi/+page.svelte
+++ b/src/routes/example/combobox/multi/+page.svelte
@@ -70,18 +70,14 @@
 				class="absolute mt-1 max-h-60 w-full overflow-auto rounded-md bg-white py-1 text-sm shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none"
 			>
 				{#each filtered as value}
-					{@const active = $combobox.active === value}
-					{@const selected = $combobox.selected.includes(value)}
 					<li
-						class="relative cursor-default select-none py-2 pl-4 pr-9 focus:outline-none {active ? 'bg-teal-600 text-white' : 'text-gray-900'}"
+						class="relative cursor-default select-none py-2 pl-4 pr-9 focus:outline-none text-gray-900 focus:bg-teal-600 focus:text-white group"
 						use:combobox.item={{ value }}
 					>
-						<span class="block truncate {selected ? 'font-semibold' : 'font-normal'}">{value.name}</span>
-						{#if selected}
-							<span class="absolute inset-y-0 right-0 flex items-center pr-3 {active ? 'text-white' : 'text-teal-600'}">
-								<Check class="h-5 w-5" />
-							</span>
-						{/if}
+						<span class="block truncate font-normal group-focus:font-semibold">{value.name}</span>
+						<span class="absolute invisible group-aria-selected:visible inset-y-0 right-0 flex items-center pr-3 text-teal-600 group-hover:text-white">
+							<Check class="h-5 w-5" />
+						</span>
 					</li>
 				{:else}
 					<li class="relative cursor-default select-none py-2 pl-10 pr-4 text-gray-900">

--- a/src/routes/example/listbox/+page.svelte
+++ b/src/routes/example/listbox/+page.svelte
@@ -43,18 +43,14 @@
 				class="absolute mt-1 max-h-60 w-full overflow-auto rounded-md bg-white py-1 text-sm shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none"
 			>
 				{#each people as value, i}
-					{@const active = $listbox.active === value}
-					{@const selected = $listbox.selected === value}
 					<li
-						class="relative cursor-default select-none py-2 pl-10 pr-4 {active ? 'bg-amber-100 text-amber-900' : 'text-gray-900'}"
+						class="relative cursor-default select-none py-2 pl-10 pr-4 text-gray-900 focus:outline-none focus:bg-amber-100 focus:text-amber-900 group"
 						use:listbox.item={{ value }}
 					>
-						<span class="block truncate {selected ? 'font-medium' : 'font-normal'}">{value.name}</span>
-						{#if selected}
-							<span class="absolute inset-y-0 left-0 flex items-center pl-3 text-amber-600">
+						<span class="block truncate font-normal group-aria-selected:font-medium">{value.name}</span>
+							<span class="absolute invisible group-aria-selected:visible inset-y-0 left-0 flex items-center pl-3 text-amber-600">
 								<Check class="h-5 w-5" />
 							</span>
-						{/if}
 					</li>
 				{/each}
 			</ul>

--- a/src/routes/example/listbox/+page.svelte
+++ b/src/routes/example/listbox/+page.svelte
@@ -44,10 +44,10 @@
 			>
 				{#each people as value, i}
 					<li
-						class="relative cursor-default select-none py-2 pl-10 pr-4 text-gray-900 focus:outline-none focus:bg-amber-100 focus:text-amber-900 group"
+						class="relative cursor-default select-none py-2 pl-10 pr-4 font-normal aria-selected:font-medium text-gray-900 focus:outline-none focus:bg-amber-100 focus:text-amber-900 group"
 						use:listbox.item={{ value }}
 					>
-						<span class="block truncate font-normal group-aria-selected:font-medium">{value.name}</span>
+						<span class="block truncate">{value.name}</span>
 							<span class="absolute invisible group-aria-selected:visible inset-y-0 left-0 flex items-center pl-3 text-amber-600">
 								<Check class="h-5 w-5" />
 							</span>

--- a/src/routes/example/listbox/multi/+page.svelte
+++ b/src/routes/example/listbox/multi/+page.svelte
@@ -62,18 +62,14 @@
 				class="absolute mt-1 max-h-60 w-full overflow-auto rounded-md bg-white py-1 text-sm shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none"
 			>
 				{#each people as value (value.id)}
-					{@const active = $listbox.active === value}
-					{@const selected = $listbox.selected.includes(value)}
 					<li
-						class="relative cursor-default select-none py-2 pl-4 pr-9 focus:outline-none {active ? 'bg-orange-100 text-orange-900' : 'text-gray-900'}"
+						class="relative cursor-default select-none py-2 pl-4 pr-9 text-gray-900 focus:outline-none focus:bg-orange-100 focus:text-orange-900 group"
 						use:listbox.item={{ value }}
 					>
-						<span class="block truncate {selected ? 'font-semibold' : 'font-normal'}">{value.name}</span>
-						{#if selected}
-							<span class="absolute inset-y-0 right-0 flex items-center pr-3 text-orange-600">
+						<span class="block truncate font-normal group-aria-selected:font-semibold">{value.name}</span>
+							<span class="absolute invisible group-aria-selected:visible inset-y-0 right-0 flex items-center pr-3 text-orange-600">
 								<Check class="h-5 w-5" />
 							</span>
-						{/if}
 					</li>
 				{/each}
 			</ul>

--- a/src/routes/example/listbox/multi/+page.svelte
+++ b/src/routes/example/listbox/multi/+page.svelte
@@ -63,10 +63,10 @@
 			>
 				{#each people as value (value.id)}
 					<li
-						class="relative cursor-default select-none py-2 pl-4 pr-9 text-gray-900 focus:outline-none focus:bg-orange-100 focus:text-orange-900 group"
+						class="relative cursor-default select-none py-2 pl-4 pr-9 font-normal aria-selected:font-medium text-gray-900 focus:outline-none focus:bg-orange-100 focus:text-orange-900 group"
 						use:listbox.item={{ value }}
 					>
-						<span class="block truncate font-normal group-aria-selected:font-semibold">{value.name}</span>
+						<span class="block truncate">{value.name}</span>
 							<span class="absolute invisible group-aria-selected:visible inset-y-0 right-0 flex items-center pr-3 text-orange-600">
 								<Check class="h-5 w-5" />
 							</span>

--- a/src/routes/example/menu/+page.svelte
+++ b/src/routes/example/menu/+page.svelte
@@ -60,7 +60,7 @@
 							{@const active = $menu.active === option.text}
 							<button
 								use:menu.item
-								class="group flex rounded-md items-center w-full px-2 py-2 text-sm {active ? 'bg-violet-500 text-white' : 'text-gray-900'}"
+								class="group flex rounded-md items-center w-full px-2 py-2 text-sm text-gray-900 focus:outline-none focus:bg-violet-500 focus:text-white"
 							>
 								<svelte:component this={option.icon} class="w-5 h-5 mr-2" {active} />
 								{option.text}


### PR DESCRIPTION
## Manage the active item via focus

Most of the AGP documentation, including examples you to manage the keyboard & mouse active item as the focus.

- [Managing Focus Within Components Using a Roving tabindex - Developing a Keyboard Interface | APG | WAI | W3C](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/#kbd_focus_discernable_predictable)
- [Combobox Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/#keyboardinteraction)
- [Listbox Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/listbox/)
- [Menu and Menubar Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/menubar/)

I suggest to change styling at the CSS selectors level if possible, rather than manipulating the styles on the JS side in the examples.

## Updated example list
- listbox, listbox multi
- combobox, combobox multi (Exclude triggering focus by dd2f1fd134123025ec5aa2148510967dad05cbfe issue)
- menu

Unfortunately, I made it a Draft PR because there is problem at keyboard interaction between Combobox items.
